### PR TITLE
Corrected issue #12.

### DIFF
--- a/fgallery
+++ b/fgallery
@@ -432,7 +432,13 @@ sub process_img
   my @backsize = @backsize;
 
   # generate main image
-  my @sfile = ($props{width}, $props{height});
+  my @sfile;
+  if ($props{'exif:Orientation'} > 4) {
+      @sfile = ($props{height}, $props{width});
+  } else {
+      @sfile = ($props{width}, $props{height});
+  }
+
   my @simg = sys('convert', $fout,
 		 '-gamma', '0.454545',
 		 '-geometry', "$maxfull[0]x$maxfull[1]>",


### PR DESCRIPTION
Image height and width are switched when EXIF:Orientation is greater than 4, resulting in a correct calculation of the thumbnail size.
See http://www.daveperrett.com/articles/2012/07/28/exif-orientation-handling-is-a-ghetto/
