### PR TITLE
fix sort by time

### DIFF
--- a/fgallery
+++ b/fgallery
@@ -509,6 +509,7 @@ sub process_img
   my %fdata;
   $fdata{props} = \%props;
   $fdata{date} = $props{date};
+  $fdata{stamp} = $props{stamp};
   $fdata{img} = [$fimg, [map { int } @simg]];
   $fdata{file} = [$ffile, [map { int } @sfile]];
   $fdata{blur} = $fblur;


### PR DESCRIPTION
The sorting wasn't working, because the 'stamp' property was not set and the sort only compared zeros.
