### PR TITLE
Strip whitespace from dates.

### DIFF
--- a/fgallery
+++ b/fgallery
@@ -429,6 +429,7 @@ foreach my $props(@aprops)
 {
   # file timestamp
   my $idate = $props->{'DateTimeOriginal'} || $props->{'DateTime'};
+  $idate =~ s/^\s+|\s+$//g;
 
   if(!$idate || $idate eq "0000:00:00 00:00:00")
   {


### PR DESCRIPTION
For some reason my dates are filled with whitespace. This gets sent to strptime and causes an error. This pull request strips whitespace from the value.