### PR TITLE
Fix tificc detection on Fedora.

### DIFF
--- a/fgallery
+++ b/fgallery
@@ -49,6 +49,7 @@ my $facedet = 0;
 my $jpegoptim = 1;
 my $pngoptim = 1;
 my $p7zip = 1;
+my $tificc = "";
 my $verbose = 0;
 my $workers = 0;
 my $sRGB = 1;
@@ -323,8 +324,14 @@ if(system("pngcrush -h >/dev/null 2>&1")) {
 if($facedet && system("facedetect -h >/dev/null 2>&1")) {
   fatal("cannot run \"facedetect\" (see http://www.thregr.org/~wavexx/software/facedetect/)");
 }
-if($sRGB && system("tificc >/dev/null 2>&1")) {
-  fatal("cannot run \"tificc\" (check if liblcms2-utils is installed)");
+if($sRGB) {
+  if(!system("tificc >/dev/null 2>&1")) {
+    $tificc = "tificc";
+  } elsif(!system("tificc2 >/dev/null 2>&1")) {
+    $tificc = "tificc2"; # Fedora
+  } else {
+    fatal("cannot run \"tificc\" or \"tificc2\" (check if liblcms2-utils is installed)");
+  }
 }
 
 my $exiftrancmd;
@@ -516,7 +523,7 @@ sub process_img
   } else
   {
     sys('convert', $fout, '-compress', 'LZW', "tiff:$ftmp");
-    sys('tificc', '-t0', $ftmp, "$ftmp.tmp");
+    sys($tificc, '-t0', $ftmp, "$ftmp.tmp");
     rename("$ftmp.tmp", $ftmp);
   }
 


### PR DESCRIPTION
```
# This is what fgallery previously searched for. Doesn't exist on Fedora.
% dnf provides /usr/bin/tificc

# This is what fgallery is now additionally trying.
% dnf provides /usr/bin/tificc2
lcms2-utils-2.7-1.fc22.x86_64 : Utility applications for lcms2

# This contains an older version, so we don't search for that.
% dnf provides /usr/bin/tifficc
lcms-1.19-13.fc22.x86_64 : Color Management System
```
