### PR TITLE
Fix file not found errors due to link fails

### DIFF
--- a/fgallery
+++ b/fgallery
@@ -654,7 +654,7 @@ sub process_img
 
   # intermediate sRGB colorspace conversion
   if(!$sRGB || ($props{ColorSpace} // 65535) == 1 || !defined($props{ProfileID})) {
-    link($fout, $ftmp);
+    link($fout, $ftmp) or sys('cp', '-L', $fout, $ftmp);
   } else
   {
     sys('convert', $fout, '-compress', 'LZW', "tiff:$ftmp");


### PR DESCRIPTION
It was giving the file not found errors. This change fixes that. Here's the error message:

    ```
    $ ./fgallery nandi/ my-gallery/ -v
    + cp -L -r /host_home/personal/fgallery/view my-gallery/
    reading completed
    + cp -L nandi/Hello-Friends copy.png my-gallery//files/Hello-Friends_copy.png
    + pngcrush -q my-gallery//files/Hello-Friends_copy.png my-gallery//files/Hello-Friends_copy.png.tmp
    + touch -r nandi/Hello-Friends copy.png my-gallery//files/Hello-Friends_copy.png
    + convert my-gallery//files/Hello-Friends_copy.png.tmp -gamma 0.454545 -geometry 1600x1200> -print %w\n%h -gamma 2.2 +profile !icc,* -quality 90 my-gallery//imgs/Hello-Friends_copy.jpg
    convert.im6: unable to open image `my-gallery//files/Hello-Friends_copy.png.tmp': No such file or directory @ error/blob.c/OpenBlob/2638.
    convert.im6: no decode delegate for this image format `my-gallery//files/Hello-Friends_copy.png.tmp' @ error/constitute.c/ReadImage/544.
    convert.im6: no images defined `my-gallery//imgs/Hello-Friends_copy.jpg' @ error/convert.c/ConvertImageCommand/3044.
    error: command "convert my-gallery//files/Hello-Friends_copy.png.tmp -gamma 0.454545 -geometry 1600x1200> -print %w\n%h -gamma 2.2 +profile !icc,* -quality 90 my-gallery//imgs/Hello-Friends_copy.jpg" failed
    ```