### PR TITLE
binmode STDOUT :utf8

### DIFF
--- a/fgallery
+++ b/fgallery
@@ -208,6 +208,9 @@ sub decode
     $cnt = 0;
     $llen = 0;
     print(pad($act . ' ...') . "\r");
+    # prevent warning regarding wide characters but without actually checking
+    # for valid UTF-8
+    binmode(STDOUT, ':utf8');
     STDOUT->flush();
   }
 


### PR DESCRIPTION
This prevents a warning regarding wide characters when printing
filenames to stdout as part of status messages, but without actually
checking for valid UTF-8 (after all, we just want to surpress the
warning).