### PR TITLE
Provide a solution for no-javascript

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,8 @@ and then navigate to http://localhost:8000.
 Pre-built packages
 ------------------
 
-Pre-built packages for `fgallery` (and `facedetect`) are available:
+Pre-built packages for `fgallery` (and `facedetect`) are available on
+Testing/Unstable:
 
 **Debian/Ubuntu**
 

--- a/README.rst
+++ b/README.rst
@@ -47,18 +47,43 @@ and then navigate to http://localhost:8000.
 Pre-built packages
 ------------------
 
-Pre-built packages for `fgallery` (and `facedetect`) are available for Debian:
+Pre-built packages for `fgallery` (and `facedetect`) are available:
+
+**Debian/Ubuntu**
 
 - https://packages.debian.org/fgallery
 - https://packages.debian.org/facedetect
 
-Arch Linux:
+Install with::
+
+  sudo apt-get install fgallery facedetect
+
+**Arch Linux**
 
 - https://aur.archlinux.org/packages/fgallery/
 
-Gentoo Linux:
+Install with::
+
+  sudo pacman -S fgallery
+
+**Gentoo Linux**
 
 - https://github.com/robert7k/gentoo-overlay/tree/master/www-apps/fgallery/
+
+Install with::
+
+  sudo layman -a robert7k
+  sudo emerge www-apps/fgallery
+
+**NixOS**
+
+- https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/graphics/fgallery/
+
+Install with::
+
+  sudo nix-env -i fgallery
+
+**Docker**
 
 You can also try the latest `fgallery` bundled with facedetect_ in a Docker
 container using the following ``Dockerfile`` provided by Stavros Korokithakis:

--- a/album/index.css
+++ b/album/index.css
@@ -50,3 +50,50 @@ h2
   text-align: center;
   outline: none;
 }
+
+#photos {
+  /* Prevent vertical gaps */
+  line-height: 0;
+  
+  -webkit-column-count: 8;
+  -webkit-column-gap:   0px;
+  -moz-column-count:    8;
+  -moz-column-gap:      0px;
+  column-count:         8;
+  column-gap:           0px;  
+}
+
+#photos img {
+  /* Just in case there are inline attributes */
+  width: 100% !important;
+  height: auto !important;
+}
+
+@media (max-width: 1200px) {
+  #photos {
+  -moz-column-count:    7;
+  -webkit-column-count: 7;
+  column-count:         7;
+  }
+}
+@media (max-width: 1000px) {
+  #photos {
+  -moz-column-count:    6;
+  -webkit-column-count: 6;
+  column-count:         6;
+  }
+}
+@media (max-width: 800px) {
+  #photos {
+  -moz-column-count:    5;
+  -webkit-column-count: 5;
+  column-count:         5;
+  }
+}
+@media (max-width: 400px) {
+  #photos {
+  -moz-column-count:    3;
+  -webkit-column-count: 3;
+  column-count:         3;
+  }
+}

--- a/fgallery
+++ b/fgallery
@@ -896,25 +896,27 @@ my $id = -1;
 my $html = qq{\n      <div id="photos" itemscope itemtype="http://schema.org/ImageGallery">\n};
 $html .= qq{\t<h1 itemprop="name">$galleryTitle</h1>\n} if $galleryTitle;
 $html .= qq{\t<p itemprop="description">$galleryDescription</p>\n} if $galleryDescription;
-$html .= qq{\t};
-$html .= join("\n\t", map {
+$html .= qq{\t<div id="wrapper">\n};
+$html .= qq{\t  };
+$html .= join("\n\t  ", map {
   $id++;
-  my $props = $_;
-  my $caption = $props->{'caption'} ? $props->{'caption'}[0] : "";
+  my $props = $_->{props};
+  my $caption = $props->{caption} ? $props->{caption}[0] : "";
   my $root = $props->{root};
   my $fbase = "$root.$ext";
-  my $file = $props->{'file'};
+  my $file = $props->{file};
   # no alt text or title attribute with caption?
   qq{<a id="$id" href="imgs/$fbase" title="$caption">}
   . qq{<img src="thumbs/$fbase" alt="$caption"/></a>}
-		} @aprops);
-$html .= qq{\n      </div>\n};
+		} @adata);
+$html .= qq{\n\t</div>\n};
+$html .= qq{      </div>\n};
 $html .= qq{    };
 my $index = slurp("$out/index.html");
 $index =~ s!<noscript>.*?</noscript>!<noscript>$html</noscript>!s;
 if ($galleryTitle && $galleryDescription && $galleryUrl) {
   # default to the first image
-  my $galleryImage = $aprops[0]->{root} . ".$ext";
+  my $galleryImage = $adata[0]->{root} . ".$ext";
   $html = qq{    <!-- for Facebook -->
     <meta property="og:title" content="$galleryTitle" />
     <meta property="og:description" content="$galleryDescription" />
@@ -935,25 +937,5 @@ unless(open($fd, ">:encoding($ENCODING)", "$out/index.html")) {
 }
 print($fd $index);
 close($fd);
-
-# don't append on repeated runs
-my $css = slurp("$out/index.css");
-if ($css !~ /\n\@media (max-width: \d+px)\n  #photos/) {
-  unless(open($fd, ">>:raw", "$out/index.css")) {
-    fatal("cannot append to new css file: $!");
-  }
-  
-  for (reverse 1..10) {
-    print($fd sprintf(q!
-@media (max-width: %dpx) {
-  #photos {
-    -moz-column-count:    %d;
-    -webkit-column-count: %d;
-    column-count:         %d;
-  }
-}!, ($_ + 0.5) * $minthumb[0], $_, $_, $_));
-  }
-  close($fd);
-}
 
 print("completed\n");

--- a/fgallery
+++ b/fgallery
@@ -220,6 +220,9 @@ sub encode
     $cnt = 0;
     $llen = 0;
     print(pad($act . ' ...') . "\r");
+    # prevent warning regarding wide characters but without actually checking
+    # for valid UTF-8
+    binmode(STDOUT, ':utf8');
     STDOUT->flush();
   }
 

--- a/fgallery
+++ b/fgallery
@@ -673,7 +673,7 @@ sub process_img
   {
     if($orient && $props{FileType} eq "JPEG" && ($props{'Orientation'} // 0))
     {
-      sys("$exiftrancmd $fout 2>/dev/null");
+      sys("$exiftrancmd '$fout' 2>/dev/null");
       if(($props{'Orientation'} // 0) > 4) {
         ($props{ImageWidth}, $props{ImageHeight}) = ($props{ImageHeight}, $props{ImageWidth});
       }

--- a/fgallery
+++ b/fgallery
@@ -113,7 +113,7 @@ sub isin
 sub slurp
 {
   my ($fn) = @_;
-  open(my $fd, $fn) or fatal("cannot read $fn: $!");
+  open(my $fd, '<', $fn) or fatal("cannot read $fn: $!");
   if($^V lt v5.23.4) {
     binmode($fd, ":encoding($ENCODING)");
   }
@@ -862,7 +862,7 @@ foreach my $fdata(@adata)
 }
 
 my $fd;
-unless(open($fd, ">:raw", "$out/data.json")) {
+unless(open($fd, '>:raw', "$out/data.json")) {
   fatal("cannot write data file: $!");
 }
 print($fd encode_json(\%json));

--- a/fgallery
+++ b/fgallery
@@ -892,14 +892,16 @@ print($fd encode_json(\%json));
 close($fd);
 
 # provide alternative for nojavascript
+my $id = -1;
 my $html = join("\n\t", map {
+  $id++;
   my $props = $_;
   my $caption = $props->{'caption'} ? $props->{'caption'}[0] : "";
   my $root = $props->{root};
   my $fbase = "$root.$ext";
   my $file = $props->{'file'};
   # no alt text or title attribute with caption?
-  qq{<a href="imgs/$fbase" title="$caption">}
+  qq{<a id="$id" href="imgs/$fbase" title="$caption">}
   . qq{<img src="thumbs/$fbase" alt="$caption"/></a>}
 		} @aprops);
 my $index = slurp("$out/index.html");

--- a/fgallery
+++ b/fgallery
@@ -887,7 +887,7 @@ my $html = join("\n\t", map {
   . qq{<img src="thumbs/$fbase" alt="$caption"/></a>}
 		} @aprops);
 my $index = slurp("$out/index.html");
-$index =~ s!<h2>.*?</h2>!<div id="photos">\n\t$html\n      </div>!;
+$index =~ s!<noscript>.*?</noscript>!<noscript>\n      <div id="photos">\n\t$html\n      </div>\n    </noscript>!s;
 unless(open($fd, ">:encoding($ENCODING)", "$out/index.html")) {
   fatal("cannot write new index file: $!");
 }

--- a/fgallery
+++ b/fgallery
@@ -875,4 +875,43 @@ unless(open($fd, '>:raw', "$out/data.json")) {
 print($fd encode_json(\%json));
 close($fd);
 
+# provide alternative for nojavascript
+my $html = join("\n\t", map {
+  my $props = $_;
+  my $caption = $props->{'caption'} ? $props->{'caption'}[0] : "";
+  my $root = $props->{root};
+  my $fbase = "$root.$ext";
+  my $file = $props->{'file'};
+  # no alt text or title attribute with caption?
+  qq{<a href="imgs/$fbase" title="$caption">}
+  . qq{<img src="thumbs/$fbase" alt="$caption"/></a>}
+		} @aprops);
+my $index = slurp("$out/index.html");
+$index =~ s!<h2>.*?</h2>!<div id="photos">\n\t$html\n      </div>!;
+unless(open($fd, ">:encoding($ENCODING)", "$out/index.html")) {
+  fatal("cannot write new index file: $!");
+}
+print($fd $index);
+close($fd);
+
+# don't append on repeated runs
+my $css = slurp("$out/index.css");
+if ($css !~ /\n\@media (max-width: \d+px)\n  #photos/) {
+  unless(open($fd, ">>:raw", "$out/index.css")) {
+    fatal("cannot append to new css file: $!");
+  }
+  
+  for (reverse 1..10) {
+    print($fd sprintf(q!
+@media (max-width: %dpx) {
+  #photos {
+    -moz-column-count:    %d;
+    -webkit-column-count: %d;
+    column-count:         %d;
+  }
+}!, ($_ + 0.5) * $minthumb[0], $_, $_, $_));
+  }
+  close($fd);
+}
+
 print("completed\n");

--- a/fgallery
+++ b/fgallery
@@ -66,7 +66,9 @@ my $workers = 0;
 my $sRGB = 1;
 my $indexUrl = undef;
 my @capmethods = ("txt", "xmp", "exif");
-
+my $galleryTitle = "";
+my $galleryDescription = "";
+my $galleryUrl = "";
 
 # support functions
 sub fatal
@@ -361,6 +363,13 @@ sub print_help
   --no-sRGB		do not remap preview/thumbnail color profiles to sRGB
   --quality Q		preview image quality (0-100, currently: $imgq)
   --index url		specify the URL location for the index/back button
+  --title "Foo"		the title to use for Facebook and Twitter previews
+  --description "bar"	the description to use for Facebook and Twitter previews
+  --url url		the URL of your gallery (should probably end with output-dir and a slash)
+
+As title, description and url are used for social media, it makes no sense to
+only provide some of these parameters. You need to provide all three of them, or
+none.
 });
   exit(shift);
 }
@@ -388,10 +397,17 @@ my ($ret, @ARGS) = GetOptions(
   'min-thumb=s' => sub { @minthumb = parse_wh(@_); },
   'no-sRGB' => sub { $sRGB = 0; },
   'quality=i' => sub { $imgq = parse_int($_[0], $_[1], 0, 100); },
-  'index=s' => sub { $indexUrl = $_[1]; });
+  'index=s' => sub { $indexUrl = $_[1]; },
+  'title=s' => sub { $galleryTitle = $_[1]; },
+  'description=s' => sub { $galleryDescription = $_[1]; },
+  'url=s' => sub { $galleryUrl = $_[1]; });
 
 if(@ARGV < 2 || @ARGV > 3 || !$ret) {
   print_help(2);
+}
+if (($galleryTitle || $galleryDescription || $galleryUrl)
+    && !($galleryTitle && $galleryDescription && $galleryUrl)) {
+  fatal("all three are required: --title, --description, and --url");
 }
 my $dir = $ARGV[0];
 my $out = $ARGV[1];
@@ -888,6 +904,24 @@ my $html = join("\n\t", map {
 		} @aprops);
 my $index = slurp("$out/index.html");
 $index =~ s!<noscript>.*?</noscript>!<noscript>\n      <div id="photos">\n\t$html\n      </div>\n    </noscript>!s;
+if ($galleryTitle && $galleryDescription && $galleryUrl) {
+  # default to the first image
+  my $galleryImage = $aprops[0]->{root} . ".$ext";
+  $html = qq{    <!-- for Facebook -->
+    <meta property="og:title" content="$galleryTitle" />
+    <meta property="og:description" content="$galleryDescription" />
+    <meta property="og:type" content="article" />
+    <meta property="og:image" content="${galleryUrl}imgs/$galleryImage" />
+    <meta property="og:url" content="$galleryUrl" />
+    <!-- for Twitter -->
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="$galleryTitle" />
+    <meta name="twitter:description" content="$galleryDescription" />
+    <meta name="twitter:image" content="${galleryUrl}imgs/$galleryImage" />
+};
+  $index =~ s/    <!-- for Facebook -->\n(    .*\n)*//;
+  $index =~ s!  </head>!$html  </head>!;
+}
 unless(open($fd, ">:encoding($ENCODING)", "$out/index.html")) {
   fatal("cannot write new index file: $!");
 }

--- a/fgallery
+++ b/fgallery
@@ -670,7 +670,7 @@ sub process_img
     $ftmp = $fout;
   } else
   {
-    sys('convert', '-quiet', $fout, '-compress', 'LZW', "tiff:$ftmp");
+    sys('convert', '-quiet', $fout, '-compress', 'LZW', '-type', 'truecolor', "tiff:$ftmp");
     sys($tificccmd, '-t0', $ftmp, "$ftmp.tmp");
     rename("$ftmp.tmp", $ftmp);
   }

--- a/fgallery
+++ b/fgallery
@@ -893,7 +893,11 @@ close($fd);
 
 # provide alternative for nojavascript
 my $id = -1;
-my $html = join("\n\t", map {
+my $html = qq{\n      <div id="photos" itemscope itemtype="http://schema.org/ImageGallery">\n};
+$html .= qq{\t<h1 itemprop="name">$galleryTitle</h1>\n} if $galleryTitle;
+$html .= qq{\t<p itemprop="description">$galleryDescription</p>\n} if $galleryDescription;
+$html .= qq{\t};
+$html .= join("\n\t", map {
   $id++;
   my $props = $_;
   my $caption = $props->{'caption'} ? $props->{'caption'}[0] : "";
@@ -904,8 +908,10 @@ my $html = join("\n\t", map {
   qq{<a id="$id" href="imgs/$fbase" title="$caption">}
   . qq{<img src="thumbs/$fbase" alt="$caption"/></a>}
 		} @aprops);
+$html .= qq{\n      </div>\n};
+$html .= qq{    };
 my $index = slurp("$out/index.html");
-$index =~ s!<noscript>.*?</noscript>!<noscript>\n      <div id="photos">\n\t$html\n      </div>\n    </noscript>!s;
+$index =~ s!<noscript>.*?</noscript>!<noscript>$html</noscript>!s;
 if ($galleryTitle && $galleryDescription && $galleryUrl) {
   # default to the first image
   my $galleryImage = $aprops[0]->{root} . ".$ext";

--- a/fgallery
+++ b/fgallery
@@ -220,9 +220,6 @@ sub encode
     $cnt = 0;
     $llen = 0;
     print(pad($act . ' ...') . "\r");
-    # prevent warning regarding wide characters but without actually checking
-    # for valid UTF-8
-    binmode(STDOUT, ':utf8');
     STDOUT->flush();
   }
 

--- a/fgallery
+++ b/fgallery
@@ -8,7 +8,8 @@ use warnings;
 
 use locale;
 use utf8;
-use open qw{:std :locale};
+use if $^V lt v5.23.4, open => qw{:std :utf8};
+use if $^V ge v5.23.4, open => qw{:std :locale};
 require Encode;
 require encoding;
 
@@ -113,6 +114,9 @@ sub slurp
 {
   my ($fn) = @_;
   open(my $fd, $fn) or fatal("cannot read $fn: $!");
+  if($^V lt v5.23.4) {
+    binmode($fd, ":encoding($ENCODING)");
+  }
   local $/;
   return <$fd> // "";
 }

--- a/fgallery
+++ b/fgallery
@@ -193,7 +193,13 @@ sub clamp
 
 sub decode
 {
-  return Encode::decode($ENCODING, shift);
+  return Encode::decode($ENCODING, shift // $_);
+}
+
+
+sub encode
+{
+  return Encode::encode($ENCODING, shift // $_);
 }
 
 
@@ -361,6 +367,7 @@ sub print_help
 
 
 # main program
+@ARGV = map(decode, @ARGV);
 my ($ret, @ARGS) = GetOptions(
   'help|h' => sub { print_help(0); },
   'version' => \&print_version,
@@ -381,14 +388,14 @@ my ($ret, @ARGS) = GetOptions(
   'min-thumb=s' => sub { @minthumb = parse_wh(@_); },
   'no-sRGB' => sub { $sRGB = 0; },
   'quality=i' => sub { $imgq = parse_int($_[0], $_[1], 0, 100); },
-  'index=s' => sub { $indexUrl = decode($_[1]); });
+  'index=s' => sub { $indexUrl = $_[1]; });
 
 if(@ARGV < 2 || @ARGV > 3 || !$ret) {
   print_help(2);
 }
 my $dir = $ARGV[0];
 my $out = $ARGV[1];
-my $name = (@ARGV < 3? undef: decode($ARGV[2]));
+my $name = (@ARGV < 3? undef: $ARGV[2]);
 
 # check paths
 my $absDir = rel2abs($dir) . '/';
@@ -459,7 +466,7 @@ find(
   no_chdir => 1,
   wanted => sub
   {
-    my $file = $_;
+    my $file = decode($_);
     return if(!-f $file);
     my ($base, undef, $suffix) = fileparse($file, qr/\.[^.]*$/);
     return if(length($suffix) < 2 || $base =~ /^\./);
@@ -468,7 +475,7 @@ find(
       push(@files, $file);
     }
   }
-}, $dir);
+}, encode($dir));
 @files = sort(@files);
 
 if(!@files) {
@@ -497,7 +504,7 @@ if($workers)
 sub analyze_file
 {
   my $file = shift;
-  my ($base, $dir, $suffix) = fileparse(decode($file), qr/\.[^.]*$/);
+  my ($base, $dir, $suffix) = fileparse($file, qr/\.[^.]*$/);
   $suffix = lc(substr($suffix, 1));
 
   progress::status("$base.$suffix");

--- a/view/index.css
+++ b/view/index.css
@@ -357,6 +357,12 @@ img
   column-gap:           0px;  
 }
 
+#photos p, #photos h1 {
+  line-height: 1em;
+  font-size: 1em;
+  padding-left: 1ex;
+}
+
 #photos img {
   /* Just in case there are inline attributes */
   width: 100% !important;

--- a/view/index.css
+++ b/view/index.css
@@ -343,3 +343,22 @@ img
 {
   background: url(cut-mov.png) top left repeat-y, url(cut-mov.png) top right repeat-y;
 }
+
+/* noscript environment, based on https://css-tricks.com/seamless-responsive-photo-grid/ */
+#photos {
+  /* Prevent vertical gaps */
+  line-height: 0;
+  /* max number of columns */
+  -webkit-column-count: 11;
+  -webkit-column-gap:   0px;
+  -moz-column-count:    11;
+  -moz-column-gap:      0px;
+  column-count:         11;
+  column-gap:           0px;  
+}
+
+#photos img {
+  /* Just in case there are inline attributes */
+  width: 100% !important;
+  height: auto !important;
+}

--- a/view/index.css
+++ b/view/index.css
@@ -1,7 +1,6 @@
 /* General reset */
 html, body
 {
-  overflow: hidden; /* IE<9 */
   padding: 0;
   margin: 0;
   border: 0;
@@ -344,27 +343,19 @@ img
   background: url(cut-mov.png) top left repeat-y, url(cut-mov.png) top right repeat-y;
 }
 
-/* noscript environment, based on https://css-tricks.com/seamless-responsive-photo-grid/ */
 #photos {
-  /* Prevent vertical gaps */
-  line-height: 0;
-  /* max number of columns */
-  -webkit-column-count: 11;
-  -webkit-column-gap:   0px;
-  -moz-column-count:    11;
-  -moz-column-gap:      0px;
-  column-count:         11;
-  column-gap:           0px;  
+    padding: 10px;
 }
 
-#photos p, #photos h1 {
-  line-height: 1em;
-  font-size: 1em;
-  padding-left: 1ex;
+#wrapper {
+    display: grid;
+    grid-gap: 5px;
+    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+    line-height: 0;
 }
 
 #photos img {
-  /* Just in case there are inline attributes */
-  width: 100% !important;
-  height: auto !important;
+  width: 100%;
+  height: 100px;
+  object-fit: cover;
 }


### PR DESCRIPTION
This involves replacing the h2 in index.html with stuff that's shows the
thumbnails and links to the images, providing alt text and title
attributes based on the first line of the caption. It also uses some CSS
tricks to arrange the thumbnails in columns based on the width of the
display.

Hopefully this will help users linking to their gallery using social
media. At least Google+ seems to pick it up.

If you want to take a look at the result, check out https://alexschroeder.ch/gallery/2016-bretagne/ and look at the source of the index.html file, or disable Javascript in your browser and reload. I didn't investigate why scrolling was disabled, I guess that's some CSS property I ought to override? I ended up scrolling using the arrow keys and liked it. Additional features to consider: the download link to the album.zip – although I don't think it's all that important.
