### PR TITLE
Handle unicode arguments

### DIFF
--- a/fgallery
+++ b/fgallery
@@ -13,6 +13,8 @@ use if $^V ge v5.23.4, open => qw{:std :locale};
 require Encode;
 require encoding;
 
+use Encode::Locale;
+
 use threads;
 use threads::shared;
 use Thread::Queue;
@@ -386,6 +388,9 @@ my ($ret, @ARGS) = GetOptions(
 if(@ARGV < 2 || @ARGV > 3 || !$ret) {
   print_help(2);
 }
+
+@ARGV = map { Encode::decode(locale => $_, 1) } @ARGV;
+
 my $dir = $ARGV[0];
 my $out = $ARGV[1];
 my $name = (@ARGV < 3? undef: decode($ARGV[2]));


### PR DESCRIPTION
This solves issue #73 

I realize this might not be the prettiest fix, last time I used perl was probably 15 years ago and I don't remember much. So feel free to give feedback or rewrite it, it does however seem to solve the issue (I got the fix from [stack overflow](http://stackoverflow.com/a/12409759)).

My understanding of the problem is that perl treats arguments as ascii, which is not always the case. This change, afaik, decodes the arguments using the users locale settings.