### PR TITLE
Add social media meta tags

### DIFF
--- a/fgallery
+++ b/fgallery
@@ -66,7 +66,9 @@ my $workers = 0;
 my $sRGB = 1;
 my $indexUrl = undef;
 my @capmethods = ("txt", "xmp", "exif");
-
+my $galleryTitle = "";
+my $galleryDescription = "";
+my $galleryUrl = "";
 
 # support functions
 sub fatal
@@ -361,6 +363,13 @@ sub print_help
   --no-sRGB		do not remap preview/thumbnail color profiles to sRGB
   --quality Q		preview image quality (0-100, currently: $imgq)
   --index url		specify the URL location for the index/back button
+  --title "Foo"		the title to use for Facebook and Twitter previews
+  --description "bar"	the description to use for Facebook and Twitter previews
+  --url url		the URL of your gallery (should probably end with output-dir and a slash)
+
+As title, description and url are used for social media, it makes no sense to
+only provide some of these parameters. You need to provide all three of them, or
+none.
 });
   exit(shift);
 }
@@ -388,10 +397,17 @@ my ($ret, @ARGS) = GetOptions(
   'min-thumb=s' => sub { @minthumb = parse_wh(@_); },
   'no-sRGB' => sub { $sRGB = 0; },
   'quality=i' => sub { $imgq = parse_int($_[0], $_[1], 0, 100); },
-  'index=s' => sub { $indexUrl = $_[1]; });
+  'index=s' => sub { $indexUrl = $_[1]; },
+  'title=s' => sub { $galleryTitle = $_[1]; },
+  'description=s' => sub { $galleryDescription = $_[1]; },
+  'url=s' => sub { $galleryUrl = $_[1]; });
 
 if(@ARGV < 2 || @ARGV > 3 || !$ret) {
   print_help(2);
+}
+if (($galleryTitle || $galleryDescription || $galleryUrl)
+    && !($galleryTitle && $galleryDescription && $galleryUrl)) {
+  fatal("all three are required: --title, --description, and --url");
 }
 my $dir = $ARGV[0];
 my $out = $ARGV[1];
@@ -873,6 +889,32 @@ unless(open($fd, '>:raw', "$out/data.json")) {
   fatal("cannot write data file: $!");
 }
 print($fd encode_json(\%json));
+close($fd);
+
+# add meta tags for social media, if and only if the info is available
+my $index = slurp("$out/index.html");
+if ($galleryTitle && $galleryDescription && $galleryUrl) {
+  # default to the first image
+  my $galleryImage = $aprops[0]->{root} . ".$ext";
+  my $html = qq{    <!-- for Facebook -->
+    <meta property="og:title" content="$galleryTitle" />
+    <meta property="og:description" content="$galleryDescription" />
+    <meta property="og:type" content="article" />
+    <meta property="og:image" content="${galleryUrl}imgs/$galleryImage" />
+    <meta property="og:url" content="$galleryUrl" />
+    <!-- for Twitter -->
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="$galleryTitle" />
+    <meta name="twitter:description" content="$galleryDescription" />
+    <meta name="twitter:image" content="${galleryUrl}imgs/$galleryImage" />
+};
+  $index =~ s/    <!-- for Facebook -->\n(    .*\n)*//;
+  $index =~ s!  </head>!$html  </head>!;
+}
+unless(open($fd, ">:encoding($ENCODING)", "$out/index.html")) {
+  fatal("cannot write new index file: $!");
+}
+print($fd $index);
 close($fd);
 
 print("completed\n");

--- a/fgallery.1
+++ b/fgallery.1
@@ -131,7 +131,22 @@ Set the JPEG quality of the preview images to
 The default is 90.
 .It Fl -index Ar URL
 Specify the URL location for the index and back buttons.
+.It Fl -title Ar TITLE
+The title for your gallery, for social media.
+.It Fl -description Ar DESCRIPTION
+A description of your gallery, for social media.
+.It Fl -url Ar URL
+The URL where you will install the gallery, for social media.
 .El
+.Ss Social Media
+Linking to your gallery on social media will not produce a nice
+preview unless you provide these three arguments: the title to use
+.Pq Fl -title Ns ,
+a short description
+.Pq Fl -description Ns ,
+and the entry URL
+.Pq Fl -url Ns .
+The first image in the gallery will be used as the preview image.
 .Sh SEE ALSO
 .Xr ImageMagick 1 ,
 .Xr exiftran 1 ,


### PR DESCRIPTION
Add more options for social media:
--title sets the title for Facebook and Twitter previews
--description sets the description
--url sets the URL of the gallery itself, once it's public

This is a stand-alone solution for #77.