### PR TITLE
Implement simple update of existing fgallery

### DIFF
--- a/fgallery
+++ b/fgallery
@@ -540,10 +540,10 @@ sub analyze_file
 
   my $root = $sane;
 
-  # FIXME: need a way to identify existing files with the
-  # autoincrement below. For the moment, this breaks for all filenames
-  # that result in duplicates after sanitzing.
-  if ($update && exists $ofiles{"imgs/$root.$ext"}) {
+  # FIXME: Need a way to identify existing files with the autoincrement below.
+  # For the moment, this breaks for all filenames that result in duplicates
+  # after sanitzing.
+  if ($update && exists $ofiles{"imgs/$root.$ext"} && -f "$out/imgs/$root.$ext") {
     return undef;
   }
 

--- a/fgallery
+++ b/fgallery
@@ -33,7 +33,7 @@ use Time::Piece;
 my $JSON_cls = eval { require Cpanel::JSON::XS; "Cpanel::JSON::XS"; } //
 	       eval { require JSON::PP; "JSON::PP"; } //
 	       fatal("either Cpanel::JSON::XS or JSON::PP is required");
-$JSON_cls->import(qw{encode_json});
+$JSON_cls->import(qw{encode_json decode_json});
 
 # constants
 our $VERSION = "1.8.2";
@@ -66,7 +66,7 @@ my $workers = 0;
 my $sRGB = 1;
 my $indexUrl = undef;
 my @capmethods = ("txt", "xmp", "exif");
-
+my $update = 0;
 
 # support functions
 sub fatal
@@ -351,6 +351,7 @@ sub print_help
   -k			do not modify files, keep original
   -t			do not time-sort
   -r			reverse album order
+  -u			update existing gallery
   -p			do not automatically include full-sized panoramas
   -d			do not generate a full album download
   -f			improve thumbnail cutting by performing face detection
@@ -382,6 +383,7 @@ my ($ret, @ARGS) = GetOptions(
   'r' => sub { $revsort = 1; },
   's' => sub { $slim = 1; },
   't' => sub { $timesort = 0; },
+  'u' => sub { $update = 1; },
   'v' => sub { $verbose = 1; },
   'max-full=s' => sub { @maxfull = parse_wh(@_); },
   'max-thumb=s' => sub { @maxthumb = parse_wh(@_); },
@@ -487,10 +489,12 @@ my $backblur = int(($minthumb[0] + $minthumb[1]) / 2 * 0.1);
 my @backsize = (int($minthumb[0] * 4), int($minthumb[1] * 3));
 
 # cleanup target paths
-for my $path("$out/thumbs", "$out/blurs", "$out/imgs", "$out/files")
-{
-  remove_tree($path);
-  make_path($path);
+unless ($update) {
+  for my $path("$out/thumbs", "$out/blurs", "$out/imgs", "$out/files")
+  {
+    remove_tree($path);
+    make_path($path);
+  }
 }
 
 # disable sub-process parallelism when threading ourselves
@@ -498,6 +502,22 @@ if($workers)
 {
   $ENV{MAGICK_THREAD_LIMIT} = 1;
   $ENV{OMP_NUM_THREADS} = 1;
+}
+
+# updates require data from the JSON file
+my @odata;
+my %ofiles;
+if ($update) {
+  # FIXME: use slurp but avoid wide character warning?
+  my $fn = "$out/data.json";
+  open(my $fd, '<:raw', $fn) or fatal("cannot read $fn: $!");
+  local $/;
+  my $json = <$fd>;
+  my $data = decode_json($json);
+  @odata = @{$data->{data}};
+  foreach(@odata) {
+    $ofiles{$_->{img}->[0]} = 1; # this is $fdata{img}
+  }
 }
 
 # 1st pass: extract/prepare input file data
@@ -519,6 +539,14 @@ sub analyze_file
   $sane =~ s/[^\w\-]/_/gu;
 
   my $root = $sane;
+
+  # FIXME: need a way to identify existing files with the
+  # autoincrement below. For the moment, this breaks for all filenames
+  # that result in duplicates after sanitzing.
+  if ($update && exists $ofiles{"imgs/$root.$ext"}) {
+    return undef;
+  }
+
   for(my $c = 0;; ++$c)
   {
     my $tmp = "$out/imgs/$root.$ext";
@@ -600,6 +628,10 @@ for(my $n = 0; $n < $#files;)
   }
   splice(@files, $n, 1);
   splice(@aprops, $n, 1);
+}
+
+unless(@files) {
+  fatal("nothing to be done");
 }
 
 # gather some statistics
@@ -866,6 +898,10 @@ foreach my $fdata(@adata)
     }
   }
   push(@{$json{data}}, \%data);
+}
+
+if ($update) {
+  $json{data} = [sort { $a->{stamp} <=> $b->{stamp} } @{$json{data}}, @odata];
 }
 
 my $fd;

--- a/fgallery.1
+++ b/fgallery.1
@@ -111,6 +111,12 @@ The default is txt,xmp,exif.
 Use
 .Ar N
 threads to process the images.
+.It Fl u
+Update an existing gallery by adding any new images. If you edit
+images or change captions, this will not be picked up. You can force
+an update of individual images my deleting them from the
+.Pa imgs
+subdirectory in the existing gallery.
 .It Fl -max-full Ar WxH
 Set the maximum full image size to
 .Ar WxH


### PR DESCRIPTION
This fails when sanitizing filenames results in duplicates (which are
then resolved by appending "_$n"). As long as your gallery has files
with names such as IMG_123.JPG you're fine. Problematic would be a
gallery containing both IMG_123 1.JPG and IMG_123_1.JPG -- the first
one gets sanitized to IMG_123_1.JPG, and the second one then has a
name collision so it gets renamed to IMG_123_1_1.JPG. In this case, if
IMG_123 1.JPG is an existing file in your gallery and IMG_123_1.JPG
is a new file in your gallery, the update will skip it since the code
checks whether IMG_123_1.JPG exists (it does) without knowing that it
should be checking IMG_123_1_1.JPG instead. In order to fix this, we
would have to store more information in data.json (or write a new file
containing this information).